### PR TITLE
Reduce memory overhead for static maps

### DIFF
--- a/EWAH.RunTests/example.cs
+++ b/EWAH.RunTests/example.cs
@@ -55,5 +55,7 @@ public class example
         tr.HabermaasTest();
         tr.VanSchaikTest();
 
+        new EWAHCompressedBitArraySerializerTest().TestCustomSerializationStrategy();
+
     }
 }

--- a/EWAH.Tests/EWAH.Tests.csproj
+++ b/EWAH.Tests/EWAH.Tests.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EWAHCompressedBitArraySerializerTest.cs" />
     <Compile Include="EWAHCompressedBitmapTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/EWAH.Tests/EWAHCompressedBitArraySerializerTest.cs
+++ b/EWAH.Tests/EWAHCompressedBitArraySerializerTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Ewah
+{
+    [TestFixture]
+    public class EWAHCompressedBitArraySerializerTest
+    {
+
+        /// <summary>
+        /// Tests the custom serialization strategy.
+        /// </summary>
+        [Test]
+        public void TestCustomSerializationStrategy() {
+            Console.WriteLine("testing Custom serialization strategy");
+
+            // Create a compressed bit array, and randomly assign up to 20,000 bits to it.
+            var bmp = new EwahCompressedBitArray();
+            var r= new Random();
+            for (int i = 0; i < 23000; i++) {
+                if (r.NextDouble() < 0.5) {
+                    bmp.Set(i);
+                }
+            }
+            
+            byte[] originalDeserialized= null;
+            byte[] newFormDeserialized= null;
+            EwahCompressedBitArray newFormReserialized= null;
+            EwahCompressedBitArray originalReserialized= null;
+
+            // First de-serialize+ re-serialize 'normally' 
+            using (var ms = new MemoryStream()) {
+                BinaryFormatter bf = new BinaryFormatter();
+                bf.Serialize(ms, bmp);
+                originalDeserialized = ms.ToArray();
+                ms.Seek(0, SeekOrigin.Begin);
+                originalReserialized = (EwahCompressedBitArray)bf.Deserialize(ms);
+            }
+
+            // Now de-serialize + re-serialize with the new form.
+            using (var ms = new MemoryStream()) {
+                EwahCompressedBitArraySerializer bf = new EwahCompressedBitArraySerializer();
+                bf.Serialize(ms, bmp);
+                newFormDeserialized = ms.ToArray();
+                ms.Seek(0, SeekOrigin.Begin);
+                newFormReserialized = (EwahCompressedBitArray)bf.Deserialize(ms);
+            }
+
+            // Assert that the new form is more compact than the original form.
+            Assert.Less(newFormDeserialized.Length, originalDeserialized.Length);
+
+            // Compare the 'normal' de-serialized + re-serialized form, against the original.
+            Assert.AreEqual(bmp, originalReserialized);
+
+            // Compare the 'new form' de-serialized + re-serialized form, against the original.
+            Assert.AreEqual(bmp, newFormReserialized);
+
+            // Compare the 'normal' de-serialized + re-serialized form, against the newly de-serialized + re-serialized form.
+            Assert.AreEqual(newFormReserialized, originalReserialized);
+
+            Console.WriteLine("testing Custom serialization strategy:ok");
+        }
+    }
+}

--- a/EWAH/EWAH.csproj
+++ b/EWAH/EWAH.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="BufferedRunningLengthWord.cs" />
     <Compile Include="EwahCompressedBitArray.cs" />
+    <Compile Include="EwahCompressedBitArraySerializer.cs" />
     <Compile Include="EwahEnumerator.cs" />
     <Compile Include="PlaceHolders.cs" />
     <Compile Include="RunningLengthWord.cs" />

--- a/EWAH/EwahCompressedBitArray.cs
+++ b/EWAH/EwahCompressedBitArray.cs
@@ -71,18 +71,18 @@ namespace Ewah
         /// <summary>
         /// current (last) running length word
         /// </summary>
-        private readonly RunningLengthWord _Rlw;
+        internal readonly RunningLengthWord _Rlw;
 
         #endregion
 
         #region Fields
 
-        private int _ActualSizeInWords = 1;
+        internal int _ActualSizeInWords = 1;
 
         /// <summary>
         /// The buffer (array of 64-bit words)
         /// </summary>
-        private long[] _Buffer;
+        internal long[] _Buffer;
 
         #endregion
 
@@ -115,11 +115,20 @@ namespace Ewah
         /// <param name="input"></param>
         /// <param name="context"></param>
         private EwahCompressedBitArray(SerializationInfo input, StreamingContext context)
-        {
-            SizeInBits = input.GetInt32("sb");
-            _ActualSizeInWords = input.GetInt32("aw");
-            _Buffer = (long[]) input.GetValue("bu", typeof (long[]));
-            _Rlw = new RunningLengthWord(_Buffer, input.GetInt32("rp"));
+            : this(input.GetInt32("sb"), input.GetInt32("aw"), (long[])input.GetValue("bu", typeof(long[])), input.GetInt32("rp"))  { }
+
+        /// <summary>
+        /// Special constructor used by serialization infrastructure
+        /// </summary>
+        /// <param name="sizeInBits">The size in bits.</param>
+        /// <param name="actualSizeInWords">The actual size in words.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="runningLengthWordPosition">The running length word position.</param>
+        internal EwahCompressedBitArray(int sizeInBits, int actualSizeInWords, long[] buffer, int runningLengthWordPosition) {
+            this.SizeInBits = sizeInBits;
+            this._ActualSizeInWords = actualSizeInWords;
+            this._Buffer = buffer;
+            this._Rlw = new RunningLengthWord(_Buffer, runningLengthWordPosition);
         }
 
         #endregion

--- a/EWAH/EwahCompressedBitArraySerializer.cs
+++ b/EWAH/EwahCompressedBitArraySerializer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+
+namespace Ewah
+{
+    /*
+     * Copyright 2012, Kemal Erdogan, Daniel Lemire and Ciaran Jessup
+     * Licensed under APL 2.0.
+     */
+    /// <summary>
+    /// A very simple Serialization schema for serialising and de-serialising instance of <see cref="Ewah.EwahCompressedBitArray"/>. 
+    /// 
+    /// The current implementation lacks serialization version information, and type information, it is rigid, brittle, simplistic but
+    /// results in less byte bloat than a traditional BinaryFormatter.
+    /// 
+    /// Consists of a very simple, fixed width header, and abritrary length buffer.
+    ///
+    /// Bytes 1-4    : 'SizeInBits'
+    /// Bytes 5-8    : 'ActualSizeInWords'
+    /// Bytes 9-12   : 'RunningLengthWordPosition'
+    /// Bytes 13-End : Contents of the internal long[] buffer
+    /// 
+    /// The encoding scheme is that of Microsoft's Built in System.BitConverter methods. Unfortunately the endian-ness of these calls
+    /// is architecture specific, so beware that to be certain of the endian order on the machine serializing this class one must use the 
+    /// BitConverter.IsLittleEndian property.
+    /// </summary>
+    public class EwahCompressedBitArraySerializer
+    {
+        /// <summary>
+        /// Deserializes the specified stream into an instance of <see cref="Ewah.EwahCompressedBitArray"/>
+        /// </summary>
+        /// <param name="serializationStream">The stream containing the data that constructs a valid instance of EwahCompressedBitArray.</param>
+        /// <returns></returns>
+        public EwahCompressedBitArray Deserialize(Stream serializationStream) {
+            byte[] buff= new byte[8];
+            serializationStream.Read(buff, 0, 4);
+            int sizeInBits = BitConverter.ToInt32(buff, 0);
+            serializationStream.Read(buff, 0, 4);
+            int actualSizeInWords = BitConverter.ToInt32(buff, 0);
+            serializationStream.Read(buff, 0, 4);
+            int runningLengthWordPosition = BitConverter.ToInt32(buff, 0);
+            long[] buffer = new long[actualSizeInWords];
+            for (int i = 0; i < actualSizeInWords; i++) {
+                serializationStream.Read(buff, 0, 8);
+                buffer[i] = BitConverter.ToInt64(buff, 0);
+            }
+            return new EwahCompressedBitArray(sizeInBits, actualSizeInWords, buffer, runningLengthWordPosition);
+        }
+
+        /// <summary>
+        /// Serializes an instance of <see cref="Ewah.EwahCompressedBitArray"/> into the given stream
+        /// </summary>
+        /// <param name="serializationStream">The serialization stream.</param>
+        /// <param name="bitArray">The bit array.</param>
+        public void Serialize(Stream serializationStream, EwahCompressedBitArray bitArray) {
+            // No actual need to call Shrink with this serialisation strategy, so we can avoid
+            // mutating the source type (side-effects are bad ;) )
+            serializationStream.Write( BitConverter.GetBytes(bitArray.SizeInBits), 0, 4 );
+            serializationStream.Write( BitConverter.GetBytes(bitArray._ActualSizeInWords),0, 4 );
+            serializationStream.Write(BitConverter.GetBytes(bitArray._Rlw.Position), 0, 4);
+            for(int i=0; i< bitArray._ActualSizeInWords;i++) {
+                serializationStream.Write(BitConverter.GetBytes(bitArray._Buffer[i]), 0, 8);
+            }
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Possibly not an issue for most people, but I'm serializing a large number of smallish bitmaps (it may be I end up serializing a smaller number of large bitmaps, but for now it is as described.)

These bitmaps, once constructed are passed 'over the wire' and used for fast lookups, i.e. never change.  

The provided commits help optimize a little for this use-case, by providing a 'Shrink' method that resizes the _Buffer field to the length of _ActualSizeInWords and by ensuring that it is called prior to serialization I no longer need to send down an excess of empty words (due to the buffer resizing)

Hope it's handy :)
