### PR TITLE
Fix V3025

### DIFF
--- a/EWAH.Tests/EWAHCompressedBitmapTest.cs
+++ b/EWAH.Tests/EWAHCompressedBitmapTest.cs
@@ -539,7 +539,7 @@ namespace Ewah
             bitmap.Set(int.MaxValue);
 
             //Assert.AreEqual(true, false);
-            Console.WriteLine("Total Items %d\n", bitmap.GetCardinality());
+            Console.WriteLine("Total Items {0:d}\n", bitmap.GetCardinality());
             Assert.AreEqual(bitmap.GetCardinality(), 1UL);
             Console.WriteLine("testing EWAH GetCardinality:ok");
         }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. 
A little bug, found using PVS-Studio: 

- V3025 Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Arguments not used: bitmap.GetCardinality(). EWAHCompressedBitmapTest.cs 542

It have to be at C#  syntax  instead oа C  syntax